### PR TITLE
Remove trailing slash from streaming endpoint

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -100,5 +100,6 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "09.01.23:", desc: "Updated nginx conf to fix bring inline with Mastodon configuration (fixes Elk integration)." }
   - { date: "19.12.22:", desc: "Support separate sidekiq queue instances." }
   - { date: "05.11.22:", desc: "Initial Release." }

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/11/07 - Changelog: https://github.com/linuxserver/docker-mastodon/commits/main/root/defaults/nginx/site-confs/default.conf.sample
+## Version 2023/01/09 - Changelog: https://github.com/linuxserver/docker-mastodon/commits/main/root/defaults/nginx/site-confs/default.conf.sample
 
 map $http_upgrade $connection_upgrade {
     default upgrade;

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -95,7 +95,7 @@ server {
         try_files $uri =404;
     }
 
-    location ^~ /api/v1/streaming/ {
+    location ^~ /api/v1/streaming {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This brings it inline with the Mastodon provided config

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mastodon/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The trailing slash here is causing nginx to incorrectly 301 redirect websocket connection requests to https://. This will not work for any client expecting a websocket. Fixes #26 

## How Has This Been Tested?
Removed slash in running container. Restarted. Streaming now works in Elk and continues to work in Mastodon.
